### PR TITLE
Fixed the cannot touch error, added CodeCov

### DIFF
--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -4,9 +4,6 @@ on:
         branches:
             - dev
             - main
-    push:
-        branches:
-            - feature/coverage-tests
 jobs:
     coverage:
         runs-on: ubuntu-latest

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -4,6 +4,11 @@ on:
         branches:
             - dev
             - main
+        paths:
+            - 'query-builder-app/**'
+            - 'query-builder-backend/**'
+            - 'coverage/**'
+            - '.github/workflows/**'
 jobs:
     coverage:
         runs-on: ubuntu-latest

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -4,6 +4,8 @@ on:
         branches:
             - dev
             - main
+    push:
+        branches:
             - feature/coverage-tests
 jobs:
     coverage:

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -4,10 +4,7 @@ on:
         branches:
             - dev
             - main
-        paths:
-            - 'query-builder-app/**'
-            - 'query-builder-backend/**'
-            - 'coverage/**'
+            - feature/coverage-tests
 jobs:
     coverage:
         runs-on: ubuntu-latest

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -43,11 +43,9 @@ jobs:
                 mkdir -p coverage  # Create the 'coverage' directory if it doesn't exist
                 touch coverage/combined-lcov.info
                 lcov -a ./query-builder-app/coverage/lcov.info -a ./query-builder-backend/coverage/lcov.info -o ./coverage/combined-lcov.info
-                ls coverage
               
             - name: Upload Coverage to Coveralls
               uses: coverallsapp/github-action@v2
               with:
                   github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
-                  base-path: coverage
                   file: combined-lcov.info

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -49,4 +49,4 @@ jobs:
               with:
                   github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
                   base-path: coverage
-                  file: coverage/combined-lcov.info
+                  file: combined-lcov.info

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -40,7 +40,6 @@ jobs:
             - name: Combining coverage data
               run: |
                 pnpm install -g lcov
-                touch ./coverage/combined-lcov.info
                 lcov -a ./query-builder-app/coverage/lcov.info -a ./query-builder-backend/coverage/lcov.info -o ./coverage/combined-lcov.info
                 cat ./coverage/combined-lcov.info
               

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -49,3 +49,4 @@ jobs:
               with:
                   github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
                   base-path: coverage
+                  file: coverage/combined-lcov.info

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -40,6 +40,7 @@ jobs:
             - name: Combining coverage data
               run: |
                 pnpm install -g lcov
+                mkdir -p coverage  # Create the 'coverage' directory if it doesn't exist
                 touch coverage/combined-lcov.info
                 lcov -a ./query-builder-app/coverage/lcov.info -a ./query-builder-backend/coverage/lcov.info -o ./coverage/combined-lcov.info
                 cat ./coverage/combined-lcov.info

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -40,6 +40,7 @@ jobs:
             - name: Combining coverage data
               run: |
                 pnpm install -g lcov
+                touch coverage/combined-lcov.info
                 lcov -a ./query-builder-app/coverage/lcov.info -a ./query-builder-backend/coverage/lcov.info -o ./coverage/combined-lcov.info
                 cat ./coverage/combined-lcov.info
               

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -9,9 +9,7 @@ on:
             - 'query-builder-backend/**'
             - 'coverage/**'
             - '.github/workflows/**'
-    push:
-        branches:
-            - feature/coverage-tests
+
 jobs:
     coverage:
         runs-on: ubuntu-latest
@@ -48,13 +46,6 @@ jobs:
                 mkdir -p coverage  # Create the 'coverage' directory if it doesn't exist
                 touch coverage/combined-lcov.info
                 lcov -a ./query-builder-app/coverage/lcov.info -a ./query-builder-backend/coverage/lcov.info -o ./coverage/combined-lcov.info
-              
-            - name: Upload Coverage to Coveralls
-              uses: coverallsapp/github-action@v2
-              with:
-                  github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
-                  base-path: coverage
-
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v4.0.1
               with:

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -9,6 +9,9 @@ on:
             - 'query-builder-backend/**'
             - 'coverage/**'
             - '.github/workflows/**'
+    push:
+        branches:
+            - feature/coverage-tests
 jobs:
     coverage:
         runs-on: ubuntu-latest
@@ -51,3 +54,8 @@ jobs:
               with:
                   github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
                   base-path: coverage
+
+            - name: Upload coverage reports to Codecov
+              uses: codecov/codecov-action@v4.0.1
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -48,4 +48,4 @@ jobs:
               uses: coverallsapp/github-action@v2
               with:
                   github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
-                  file: combined-lcov.info
+                  base-path: coverage

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -1,5 +1,6 @@
 name: Code Coverage
 on: 
+    workflow_dispatch:
     pull_request:
         branches:
             - dev

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -43,7 +43,7 @@ jobs:
                 mkdir -p coverage  # Create the 'coverage' directory if it doesn't exist
                 touch coverage/combined-lcov.info
                 lcov -a ./query-builder-app/coverage/lcov.info -a ./query-builder-backend/coverage/lcov.info -o ./coverage/combined-lcov.info
-                ls
+                ls coverage
               
             - name: Upload Coverage to Coveralls
               uses: coverallsapp/github-action@v2

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -43,6 +43,7 @@ jobs:
                 mkdir -p coverage  # Create the 'coverage' directory if it doesn't exist
                 touch coverage/combined-lcov.info
                 lcov -a ./query-builder-app/coverage/lcov.info -a ./query-builder-backend/coverage/lcov.info -o ./coverage/combined-lcov.info
+                ls
               
             - name: Upload Coverage to Coveralls
               uses: coverallsapp/github-action@v2

--- a/.github/workflows/tests-code-coverage.yaml
+++ b/.github/workflows/tests-code-coverage.yaml
@@ -43,10 +43,9 @@ jobs:
                 mkdir -p coverage  # Create the 'coverage' directory if it doesn't exist
                 touch coverage/combined-lcov.info
                 lcov -a ./query-builder-app/coverage/lcov.info -a ./query-builder-backend/coverage/lcov.info -o ./coverage/combined-lcov.info
-                cat ./coverage/combined-lcov.info
               
             - name: Upload Coverage to Coveralls
               uses: coverallsapp/github-action@v2
               with:
                   github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
-                  path-to-lcov: coverage/combined-lcov.info
+                  base-path: coverage


### PR DESCRIPTION
Fixed the error Github Actions threw when combining the coverage files - but it seems that neither Coveralls, nor CodeCov (which I added) are picking up the combined coverage file. CodeCov however seems to combine multiple coverage files on their site itself though - see: https://app.codecov.io/gh/COS301-SE-2024/Query-Builder/tree/feature%2Fcoverage-tests